### PR TITLE
Add default value to the getter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $data = new Data(array(
             'username' => 'dman',
             'password' => 'D---S',
             'roles' => array('web', 'db'),
+            'nick' => 'dewey dman'
         ),
         'lewey' => array(
             'username' => 'lman',
@@ -66,6 +67,10 @@ $username = $data->get('hosts.hewey.username');
 $password = $data->get('hosts.hewey.password');
 // array('web')
 $roles = $data->get('hosts.hewey.roles');
+// dewey dman
+$nick = $data->get('hosts.dewey.nick');
+// Unknown
+$nick = $data->get('hosts.lewey.nick', 'Unknown');
 
 // DataInterface instance
 $dewey = $data->getData('hosts.dewey');

--- a/src/Dflydev/DotAccessData/Data.php
+++ b/src/Dflydev/DotAccessData/Data.php
@@ -140,7 +140,7 @@ class Data implements DataInterface
     /**
      * {@inheritdoc}
      */
-    public function get($key)
+    public function get($key, $default = null)
     {
         $currentValue = $this->data;
         $keyPath = explode('.', $key);
@@ -148,15 +148,15 @@ class Data implements DataInterface
         for ( $i = 0; $i < count($keyPath); $i++ ) {
             $currentKey = $keyPath[$i];
             if (!isset($currentValue[$currentKey]) ) {
-                return null;
+                return $default;
             }
             if (!is_array($currentValue)) {
-                return null;
+                return $default;
             }
             $currentValue = $currentValue[$currentKey];
         }
 
-        return $currentValue;
+        return $currentValue === null ? $default : $currentValue;
     }
 
     /**

--- a/src/Dflydev/DotAccessData/DataInterface.php
+++ b/src/Dflydev/DotAccessData/DataInterface.php
@@ -40,10 +40,11 @@ interface DataInterface
      * Get the raw value for a key
      *
      * @param string $key
+     * @param mixed $default
      *
      * @return mixed
      */
-    public function get($key);
+    public function get($key, $default = null);
 
     /**
      * Get a data instance for a key

--- a/tests/Dflydev/DotAccessData/DataTest.php
+++ b/tests/Dflydev/DotAccessData/DataTest.php
@@ -2,7 +2,7 @@
 
 /*
  * This file is a part of dflydev/dot-access-data.
- * 
+ *
  * (c) Dragonfly Development Inc.
  *
  * For the full copyright and license information, please view the LICENSE
@@ -50,6 +50,8 @@ class DataTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('c1', 'c2', 'c3'), $data->get('c'));
         $this->assertNull($data->get('foo'), 'Foo should not exist');
         $this->assertNull($data->get('f.g.h.i'));
+        $this->assertEquals($data->get('foo', 'default-value-1'), 'default-value-1', 'Return default value');
+        $this->assertEquals($data->get('f.g.h.i', 'default-value-2'), 'default-value-2');
     }
 
     public function testAppend()


### PR DESCRIPTION
Add the ability to define a default value when the getter method is called. If no key is found, the default value will be returned, otherwise null.