### PR TITLE
Fixing has() to recognize keys with null value.

### DIFF
--- a/src/Dflydev/DotAccessData/Data.php
+++ b/src/Dflydev/DotAccessData/Data.php
@@ -171,7 +171,7 @@ class Data implements DataInterface
             $currentKey = $keyPath[$i];
             if (
                 !is_array($currentValue) ||
-                !isset($currentValue[$currentKey])
+                !array_key_exists($currentKey, $currentValue)
             ) {
                 return false;
             }


### PR DESCRIPTION
Currently, `$data->has('key')` will return FALSE if the value of said key is NULL. This PR resolves the issue.