### PR TITLE
Implement more-specific exceptions

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -11,8 +11,9 @@
 
 namespace Dflydev\DotAccessData;
 
-use RuntimeException;
 use ArrayAccess;
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
 
 /**
  * @implements ArrayAccess<string, mixed>
@@ -42,7 +43,7 @@ class Data implements DataInterface, ArrayAccess
     public function append(string $key, $value = null): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -88,7 +89,7 @@ class Data implements DataInterface, ArrayAccess
     public function set(string $key, $value = null): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -107,7 +108,7 @@ class Data implements DataInterface, ArrayAccess
                 $currentValue[$currentKey] = [];
             }
             if (!is_array($currentValue[$currentKey])) {
-                throw new RuntimeException("Key path at $currentKey of $key cannot be indexed into (is not an array)");
+                throw new DataException("Key path at $currentKey of $key cannot be indexed into (is not an array)");
             }
             $currentValue =& $currentValue[$currentKey];
         }
@@ -120,7 +121,7 @@ class Data implements DataInterface, ArrayAccess
     public function remove(string $key): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -203,7 +204,7 @@ class Data implements DataInterface, ArrayAccess
             return new Data($value);
         }
 
-        throw new RuntimeException("Value at '$key' could not be represented as a DataInterface");
+        throw new DataException("Value at '$key' could not be represented as a DataInterface");
     }
 
     /**

--- a/src/Data.php
+++ b/src/Data.php
@@ -14,6 +14,9 @@ namespace Dflydev\DotAccessData;
 use RuntimeException;
 use ArrayAccess;
 
+/**
+ * @implements ArrayAccess<string, mixed>
+ */
 class Data implements DataInterface, ArrayAccess
 {
     /**
@@ -247,6 +250,8 @@ class Data implements DataInterface, ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @param string $key
      */
     public function offsetSet($key, $value)
     {
@@ -260,5 +265,4 @@ class Data implements DataInterface, ArrayAccess
     {
         $this->remove($key);
     }
-
 }

--- a/src/DataInterface.php
+++ b/src/DataInterface.php
@@ -11,6 +11,9 @@
 
 namespace Dflydev\DotAccessData;
 
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
+
 interface DataInterface
 {
     /**
@@ -18,6 +21,8 @@ interface DataInterface
      *
      * @param string $key
      * @param mixed  $value
+     *
+     * @throws InvalidPathException if the given path is empty
      */
     public function append(string $key, $value = null): void;
 
@@ -26,6 +31,9 @@ interface DataInterface
      *
      * @param string $key
      * @param mixed  $value
+     *
+     * @throws InvalidPathException if the given path is empty
+     * @throws DataException if the given path does not target an array
      */
     public function set(string $key, $value = null): void;
 
@@ -33,6 +41,8 @@ interface DataInterface
      * Remove a key
      *
      * @param string $key
+     *
+     * @throws InvalidPathException if the given path is empty
      */
     public function remove(string $key): void;
 
@@ -65,6 +75,8 @@ interface DataInterface
      * @param string $key
      *
      * @return DataInterface
+     *
+     * @throws DataException if the given path does not reference an array
      *
      * @psalm-mutation-free
      */

--- a/src/Exception/DataException.php
+++ b/src/Exception/DataException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is a part of dflydev/dot-access-data.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dflydev\DotAccessData\Exception;
+
+/**
+ * Base runtime exception type thrown by this library
+ */
+class DataException extends \RuntimeException
+{
+}

--- a/src/Exception/InvalidPathException.php
+++ b/src/Exception/InvalidPathException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is a part of dflydev/dot-access-data.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dflydev\DotAccessData\Exception;
+
+/**
+ * Thrown when trying to access an invalid path in the data array
+ */
+class InvalidPathException extends DataException
+{
+}

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -240,10 +240,6 @@ class DataTest extends TestCase
         $this->assertEquals(['c1', 'c2', 'c3'], $data['c']);
         $this->assertNull($data['foo'], 'Foo should not exist');
         $this->assertNull($data['f.g.h.i']);
-
-        $this->expectException(RuntimeException::class);
-
-        $data = $wrappedData->getData('wrapped.sampleData.a');
     }
 
     public function testOffsetSet()

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -248,7 +248,7 @@ class DataTest extends TestCase
 
     public function testOffsetSet()
     {
-        $data = new Data;
+        $data = new Data();
 
         $this->assertNull($data['a']);
         $this->assertNull($data['b.c']);

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -11,7 +11,8 @@
 
 namespace Dflydev\DotAccessData;
 
-use RuntimeException;
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
 use PHPUnit\Framework\TestCase;
 
 class DataTest extends TestCase
@@ -81,7 +82,7 @@ class DataTest extends TestCase
         $this->assertEquals(['I', 'I2'], $data->get('h.i'));
         $this->assertEquals(['L'], $data->get('i.k.l'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->append('', 'broken');
     }
@@ -104,7 +105,7 @@ class DataTest extends TestCase
         $this->assertEquals('F', $data->get('d.e.f'));
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data->get('d'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->set('', 'broken');
     }
@@ -115,7 +116,7 @@ class DataTest extends TestCase
 
         $data->set('a.b.c', 'Should not be able to write to a.b.c.d.e');
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DataException::class);
 
         $data->set('a.b.c.d.e', 'broken');
     }
@@ -137,7 +138,7 @@ class DataTest extends TestCase
         $this->assertNull(null);
         $this->assertEquals('D2', $data->get('b.d.d2'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->remove('', 'broken');
     }
@@ -178,7 +179,7 @@ class DataTest extends TestCase
 
         $this->runSampleDataTests($data);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DataException::class);
 
         $data = $wrappedData->getData('wrapped.sampleData.a');
     }
@@ -260,7 +261,7 @@ class DataTest extends TestCase
         $this->assertEquals('F', $data['d.e.f']);
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data['d']);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->set('', 'broken');
     }
@@ -282,7 +283,7 @@ class DataTest extends TestCase
         $this->assertNull(null);
         $this->assertEquals('D2', $data['b.d.d2']);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         unset($data['']);
     }


### PR DESCRIPTION
This PR introduces two new types of exceptions to help developers better differentiate between generic errors and those specific to certain invalid uses of this library.