### PR TITLE
Allow slash-delimited paths (hard coded)

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -11,8 +11,9 @@
 
 namespace Dflydev\DotAccessData;
 
-use RuntimeException;
 use ArrayAccess;
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
 
 /**
  * @implements ArrayAccess<string, mixed>
@@ -42,7 +43,7 @@ class Data implements DataInterface, ArrayAccess
     public function append(string $key, $value = null): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -88,7 +89,7 @@ class Data implements DataInterface, ArrayAccess
     public function set(string $key, $value = null): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -107,7 +108,7 @@ class Data implements DataInterface, ArrayAccess
                 $currentValue[$currentKey] = [];
             }
             if (!is_array($currentValue[$currentKey])) {
-                throw new RuntimeException("Key path at $currentKey of $key cannot be indexed into (is not an array)");
+                throw new DataException("Key path at $currentKey of $key cannot be indexed into (is not an array)");
             }
             $currentValue =& $currentValue[$currentKey];
         }
@@ -120,7 +121,7 @@ class Data implements DataInterface, ArrayAccess
     public function remove(string $key): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -203,7 +204,7 @@ class Data implements DataInterface, ArrayAccess
             return new Data($value);
         }
 
-        throw new RuntimeException("Value at '$key' could not be represented as a DataInterface");
+        throw new DataException("Value at '$key' could not be represented as a DataInterface");
     }
 
     /**

--- a/src/Data.php
+++ b/src/Data.php
@@ -14,6 +14,9 @@ namespace Dflydev\DotAccessData;
 use RuntimeException;
 use ArrayAccess;
 
+/**
+ * @implements ArrayAccess<string, mixed>
+ */
 class Data implements DataInterface, ArrayAccess
 {
     /**
@@ -247,6 +250,8 @@ class Data implements DataInterface, ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @param string $key
      */
     public function offsetSet($key, $value)
     {
@@ -260,5 +265,4 @@ class Data implements DataInterface, ArrayAccess
     {
         $this->remove($key);
     }
-
 }

--- a/src/Data.php
+++ b/src/Data.php
@@ -20,6 +20,8 @@ use Dflydev\DotAccessData\Exception\InvalidPathException;
  */
 class Data implements DataInterface, ArrayAccess
 {
+    private const DELIMITERS = ['.', '/'];
+
     /**
      * Internal representation of data data
      *
@@ -267,6 +269,8 @@ class Data implements DataInterface, ArrayAccess
         if (\strlen($path) === 0) {
             throw new InvalidPathException('Path cannot be an empty string');
         }
+
+        $path = \str_replace(self::DELIMITERS, '.', $path);
 
         return \explode('.', $path);
     }

--- a/src/Data.php
+++ b/src/Data.php
@@ -42,12 +42,8 @@ class Data implements DataInterface, ArrayAccess
      */
     public function append(string $key, $value = null): void
     {
-        if (0 == strlen($key)) {
-            throw new InvalidPathException("Key cannot be an empty string");
-        }
-
         $currentValue =& $this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         if (1 == count($keyPath)) {
             if (!isset($currentValue[$key])) {
@@ -88,12 +84,8 @@ class Data implements DataInterface, ArrayAccess
      */
     public function set(string $key, $value = null): void
     {
-        if (0 == strlen($key)) {
-            throw new InvalidPathException("Key cannot be an empty string");
-        }
-
         $currentValue =& $this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         if (1 == count($keyPath)) {
             $currentValue[$key] = $value;
@@ -120,12 +112,8 @@ class Data implements DataInterface, ArrayAccess
      */
     public function remove(string $key): void
     {
-        if (0 == strlen($key)) {
-            throw new InvalidPathException("Key cannot be an empty string");
-        }
-
         $currentValue =& $this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         if (1 == count($keyPath)) {
             unset($currentValue[$key]);
@@ -152,7 +140,7 @@ class Data implements DataInterface, ArrayAccess
     public function get(string $key, $default = null)
     {
         $currentValue = $this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         for ($i = 0; $i < count($keyPath); $i++) {
             $currentKey = $keyPath[$i];
@@ -176,7 +164,7 @@ class Data implements DataInterface, ArrayAccess
     public function has(string $key): bool
     {
         $currentValue = &$this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         for ($i = 0; $i < count($keyPath); $i++) {
             $currentKey = $keyPath[$i];
@@ -265,5 +253,21 @@ class Data implements DataInterface, ArrayAccess
     public function offsetUnset($key)
     {
         $this->remove($key);
+    }
+
+    /**
+     * @return string[]
+     *
+     * @psalm-return non-empty-list<string>
+     *
+     * @psalm-pure
+     */
+    protected function keyToPathArray(string $path): array
+    {
+        if (\strlen($path) === 0) {
+            throw new InvalidPathException('Path cannot be an empty string');
+        }
+
+        return \explode('.', $path);
     }
 }

--- a/src/DataInterface.php
+++ b/src/DataInterface.php
@@ -11,6 +11,9 @@
 
 namespace Dflydev\DotAccessData;
 
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
+
 interface DataInterface
 {
     /**
@@ -18,6 +21,8 @@ interface DataInterface
      *
      * @param string $key
      * @param mixed  $value
+     *
+     * @throws InvalidPathException if the given path is empty
      */
     public function append(string $key, $value = null): void;
 
@@ -26,6 +31,9 @@ interface DataInterface
      *
      * @param string $key
      * @param mixed  $value
+     *
+     * @throws InvalidPathException if the given path is empty
+     * @throws DataException if the given path does not target an array
      */
     public function set(string $key, $value = null): void;
 
@@ -33,6 +41,8 @@ interface DataInterface
      * Remove a key
      *
      * @param string $key
+     *
+     * @throws InvalidPathException if the given path is empty
      */
     public function remove(string $key): void;
 
@@ -65,6 +75,8 @@ interface DataInterface
      * @param string $key
      *
      * @return DataInterface
+     *
+     * @throws DataException if the given path does not reference an array
      *
      * @psalm-mutation-free
      */

--- a/src/Exception/DataException.php
+++ b/src/Exception/DataException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is a part of dflydev/dot-access-data.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dflydev\DotAccessData\Exception;
+
+/**
+ * Base runtime exception type thrown by this library
+ */
+class DataException extends \RuntimeException
+{
+}

--- a/src/Exception/InvalidPathException.php
+++ b/src/Exception/InvalidPathException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is a part of dflydev/dot-access-data.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dflydev\DotAccessData\Exception;
+
+/**
+ * Thrown when trying to access an invalid path in the data array
+ */
+class InvalidPathException extends DataException
+{
+}

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -56,6 +56,9 @@ class DataTest extends TestCase
         $this->assertNull($data->get('f.g.h.i'));
         $this->assertEquals($data->get('foo', 'default-value-1'), 'default-value-1', 'Return default value');
         $this->assertEquals($data->get('f.g.h.i', 'default-value-2'), 'default-value-2');
+
+        $this->expectException(InvalidPathException::class);
+        $data->get('', 'broken');
     }
 
     public function testAppend()
@@ -165,6 +168,9 @@ class DataTest extends TestCase
         ) {
             $this->assertFalse($data->has($notExistentKey));
         }
+
+        $this->expectException(InvalidPathException::class);
+        $data->has('', 'broken');
     }
 
     public function testGetData()

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -240,10 +240,6 @@ class DataTest extends TestCase
         $this->assertEquals(['c1', 'c2', 'c3'], $data['c']);
         $this->assertNull($data['foo'], 'Foo should not exist');
         $this->assertNull($data['f.g.h.i']);
-
-        $this->expectException(RuntimeException::class);
-
-        $data = $wrappedData->getData('wrapped.sampleData.a');
     }
 
     public function testOffsetSet()

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -248,7 +248,7 @@ class DataTest extends TestCase
 
     public function testOffsetSet()
     {
-        $data = new Data;
+        $data = new Data();
 
         $this->assertNull($data['a']);
         $this->assertNull($data['b.c']);

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -11,7 +11,8 @@
 
 namespace Dflydev\DotAccessData;
 
-use RuntimeException;
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
 use PHPUnit\Framework\TestCase;
 
 class DataTest extends TestCase
@@ -81,7 +82,7 @@ class DataTest extends TestCase
         $this->assertEquals(['I', 'I2'], $data->get('h.i'));
         $this->assertEquals(['L'], $data->get('i.k.l'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->append('', 'broken');
     }
@@ -104,7 +105,7 @@ class DataTest extends TestCase
         $this->assertEquals('F', $data->get('d.e.f'));
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data->get('d'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->set('', 'broken');
     }
@@ -115,7 +116,7 @@ class DataTest extends TestCase
 
         $data->set('a.b.c', 'Should not be able to write to a.b.c.d.e');
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DataException::class);
 
         $data->set('a.b.c.d.e', 'broken');
     }
@@ -137,7 +138,7 @@ class DataTest extends TestCase
         $this->assertNull(null);
         $this->assertEquals('D2', $data->get('b.d.d2'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->remove('', 'broken');
     }
@@ -178,7 +179,7 @@ class DataTest extends TestCase
 
         $this->runSampleDataTests($data);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DataException::class);
 
         $data = $wrappedData->getData('wrapped.sampleData.a');
     }
@@ -260,7 +261,7 @@ class DataTest extends TestCase
         $this->assertEquals('F', $data['d.e.f']);
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data['d']);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->set('', 'broken');
     }
@@ -282,7 +283,7 @@ class DataTest extends TestCase
         $this->assertNull(null);
         $this->assertEquals('D2', $data['b.d.d2']);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         unset($data['']);
     }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -49,13 +49,18 @@ class DataTest extends TestCase
     {
         $this->assertEquals('A', $data->get('a'));
         $this->assertEquals('B', $data->get('b.b'));
+        $this->assertEquals('B', $data->get('b/b'));
         $this->assertEquals(['C1', 'C2', 'C3'], $data->get('b.c'));
+        $this->assertEquals(['C1', 'C2', 'C3'], $data->get('b/c'));
         $this->assertEquals('D3', $data->get('b.d.d3'));
+        $this->assertEquals('D3', $data->get('b/d/d3'));
         $this->assertEquals(['c1', 'c2', 'c3'], $data->get('c'));
-        $this->assertNull($data->get('foo'), 'Foo should not exist');
-        $this->assertNull($data->get('f.g.h.i'));
+        $this->assertNull($data->get('foo', null), 'Foo should not exist');
+        $this->assertNull($data->get('f.g.h.i', null));
+        $this->assertNull($data->get('f/g/h/i', null));
         $this->assertEquals($data->get('foo', 'default-value-1'), 'default-value-1', 'Return default value');
         $this->assertEquals($data->get('f.g.h.i', 'default-value-2'), 'default-value-2');
+        $this->assertEquals($data->get('f/g/h/i', 'default-value-2'), 'default-value-2');
 
         $this->expectException(InvalidPathException::class);
         $data->get('', 'broken');
@@ -68,12 +73,12 @@ class DataTest extends TestCase
         $data->append('a', 'B');
         $data->append('c', 'c4');
         $data->append('b.c', 'C4');
-        $data->append('b.d.d3', 'D3b');
+        $data->append('b/d/d3', 'D3b');
         $data->append('b.d.d4', 'D');
         $data->append('e', 'E');
-        $data->append('f.a', 'b');
+        $data->append('f/a', 'b');
         $data->append('h.i', 'I2');
-        $data->append('i.k.l', 'L');
+        $data->append('i/k/l', 'L');
 
         $this->assertEquals(['A', 'B'], $data->get('a'));
         $this->assertEquals(['c1', 'c2', 'c3', 'c4'], $data->get('c'));
@@ -94,18 +99,18 @@ class DataTest extends TestCase
     {
         $data = new Data();
 
-        $this->assertNull($data->get('a'));
-        $this->assertNull($data->get('b.c'));
-        $this->assertNull($data->get('d.e'));
+        $this->assertNull($data->get('a', null));
+        $this->assertNull($data->get('b/c', null));
+        $this->assertNull($data->get('d.e', null));
 
         $data->set('a', 'A');
-        $data->set('b.c', 'C');
+        $data->set('b/c', 'C');
         $data->set('d.e', ['f' => 'F', 'g' => 'G']);
 
         $this->assertEquals('A', $data->get('a'));
         $this->assertEquals(['c' => 'C'], $data->get('b'));
         $this->assertEquals('C', $data->get('b.c'));
-        $this->assertEquals('F', $data->get('d.e.f'));
+        $this->assertEquals('F', $data->get('d/e/f'));
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data->get('d'));
 
         $this->expectException(InvalidPathException::class);
@@ -130,13 +135,13 @@ class DataTest extends TestCase
 
         $data->remove('a');
         $data->remove('b.c');
-        $data->remove('b.d.d3');
+        $data->remove('b/d/d3');
         $data->remove('d');
         $data->remove('d.e.f');
         $data->remove('empty.path');
 
         $this->assertNull($data->get('a'));
-        $this->assertNull($data->get('b.c'));
+        $this->assertNull($data->get('b/c'));
         $this->assertNull($data->get('b.d.d3'));
         $this->assertNull(null);
         $this->assertEquals('D2', $data->get('b.d.d2'));
@@ -158,13 +163,13 @@ class DataTest extends TestCase
         $data = new Data($this->getSampleData());
 
         foreach (
-            ['a', 'i', 'b.d', 'f.g.h', 'h.i', 'b.d.d1'] as $existentKey
+            ['a', 'i', 'b.d', 'b/d', 'f.g.h', 'f/g/h', 'h.i', 'h/i', 'b.d.d1', 'b/d/d1'] as $existentKey
         ) {
             $this->assertTrue($data->has($existentKey));
         }
 
         foreach (
-            ['p', 'b.b1', 'b.c.C1', 'h.i.I', 'b.d.d1.D1'] as $notExistentKey
+            ['p', 'b.b1', 'b/b1', 'b.c.C1', 'b/c/C1', 'h.i.I', 'h/i/I', 'b.d.d1.D1', 'b/d/d1/D1'] as $notExistentKey
         ) {
             $this->assertFalse($data->has($notExistentKey));
         }
@@ -218,13 +223,13 @@ class DataTest extends TestCase
         $data = new Data($this->getSampleData());
 
         foreach (
-            ['a', 'i', 'b.d', 'f.g.h', 'h.i', 'b.d.d1'] as $existentKey
+            ['a', 'i', 'b.d', 'b/d', 'f.g.h', 'f/g/h', 'h.i', 'h/i', 'b.d.d1', 'b/d/d1'] as $existentKey
         ) {
             $this->assertTrue(isset($data[$existentKey]));
         }
 
         foreach (
-            ['p', 'b.b1', 'b.c.C1', 'h.i.I', 'b.d.d1.D1'] as $notExistentKey
+            ['p', 'b.b1', 'b/b1', 'b.c.C1', 'b/c/C1', 'h.i.I', 'h/i/I', 'b.d.d1.D1', 'b/d/d1/D1'] as $notExistentKey
         ) {
             $this->assertFalse(isset($data[$notExistentKey]));
         }
@@ -242,11 +247,15 @@ class DataTest extends TestCase
 
         $this->assertEquals('A', $data['a']);
         $this->assertEquals('B', $data['b.b']);
+        $this->assertEquals('B', $data['b/b']);
         $this->assertEquals(['C1', 'C2', 'C3'], $data['b.c']);
+        $this->assertEquals(['C1', 'C2', 'C3'], $data['b/c']);
         $this->assertEquals('D3', $data['b.d.d3']);
+        $this->assertEquals('D3', $data['b/d/d3']);
         $this->assertEquals(['c1', 'c2', 'c3'], $data['c']);
         $this->assertNull($data['foo'], 'Foo should not exist');
         $this->assertNull($data['f.g.h.i']);
+        $this->assertNull($data['f/g/h/i']);
     }
 
     public function testOffsetSet()
@@ -257,14 +266,14 @@ class DataTest extends TestCase
         $this->assertNull($data['b.c']);
         $this->assertNull($data['d.e']);
 
-        $data['a'] = 'A';
-        $data['b.c'] = 'C';
+        $data['a']   = 'A';
+        $data['b/c'] = 'C';
         $data['d.e'] = ['f' => 'F', 'g' => 'G'];
 
         $this->assertEquals('A', $data['a']);
         $this->assertEquals(['c' => 'C'], $data['b']);
         $this->assertEquals('C', $data['b.c']);
-        $this->assertEquals('F', $data['d.e.f']);
+        $this->assertEquals('F', $data['d/e/f']);
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data['d']);
 
         $this->expectException(InvalidPathException::class);
@@ -277,7 +286,7 @@ class DataTest extends TestCase
         $data = new Data($this->getSampleData());
 
         unset($data['a']);
-        unset($data['b.c']);
+        unset($data['b/c']);
         unset($data['b.d.d3']);
         unset($data['d']);
         unset($data['d.e.f']);
@@ -285,7 +294,7 @@ class DataTest extends TestCase
 
         $this->assertNull($data['a']);
         $this->assertNull($data['b.c']);
-        $this->assertNull($data['b.d.d3']);
+        $this->assertNull($data['b/d/d3']);
         $this->assertNull(null);
         $this->assertEquals('D2', $data['b.d.d2']);
 


### PR DESCRIPTION
This PR is one possible implementation for #21 (the alternative being #25)  In this one, dots and slashes are both allowed in all `Data` instances and this cannot be adjusted.

Note that #23 should be merged before this one.