### PR TITLE
Allow slash-delimited paths (configurable)

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -11,8 +11,9 @@
 
 namespace Dflydev\DotAccessData;
 
-use RuntimeException;
 use ArrayAccess;
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
 
 /**
  * @implements ArrayAccess<string, mixed>
@@ -42,7 +43,7 @@ class Data implements DataInterface, ArrayAccess
     public function append(string $key, $value = null): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -88,7 +89,7 @@ class Data implements DataInterface, ArrayAccess
     public function set(string $key, $value = null): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -107,7 +108,7 @@ class Data implements DataInterface, ArrayAccess
                 $currentValue[$currentKey] = [];
             }
             if (!is_array($currentValue[$currentKey])) {
-                throw new RuntimeException("Key path at $currentKey of $key cannot be indexed into (is not an array)");
+                throw new DataException("Key path at $currentKey of $key cannot be indexed into (is not an array)");
             }
             $currentValue =& $currentValue[$currentKey];
         }
@@ -120,7 +121,7 @@ class Data implements DataInterface, ArrayAccess
     public function remove(string $key): void
     {
         if (0 == strlen($key)) {
-            throw new RuntimeException("Key cannot be an empty string");
+            throw new InvalidPathException("Key cannot be an empty string");
         }
 
         $currentValue =& $this->data;
@@ -203,7 +204,7 @@ class Data implements DataInterface, ArrayAccess
             return new Data($value);
         }
 
-        throw new RuntimeException("Value at '$key' could not be represented as a DataInterface");
+        throw new DataException("Value at '$key' could not be represented as a DataInterface");
     }
 
     /**

--- a/src/Data.php
+++ b/src/Data.php
@@ -14,6 +14,9 @@ namespace Dflydev\DotAccessData;
 use RuntimeException;
 use ArrayAccess;
 
+/**
+ * @implements ArrayAccess<string, mixed>
+ */
 class Data implements DataInterface, ArrayAccess
 {
     /**
@@ -247,6 +250,8 @@ class Data implements DataInterface, ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @param string $key
      */
     public function offsetSet($key, $value)
     {
@@ -260,5 +265,4 @@ class Data implements DataInterface, ArrayAccess
     {
         $this->remove($key);
     }
-
 }

--- a/src/Data.php
+++ b/src/Data.php
@@ -21,6 +21,14 @@ use Dflydev\DotAccessData\Exception\InvalidPathException;
 class Data implements DataInterface, ArrayAccess
 {
     /**
+     * Allowed path delimiters
+     * @var array<int, string>
+     *
+     * @psalm-mutation-free
+     */
+    private $delimiters = [];
+
+    /**
      * Internal representation of data data
      *
      * @var array<string, mixed>
@@ -31,10 +39,13 @@ class Data implements DataInterface, ArrayAccess
      * Constructor
      *
      * @param array<string, mixed> $data
+     * @param array<int, string>   $delimiters
      */
-    public function __construct(array $data = [])
+    public function __construct(array $data = [], array $delimiters = ['.'])
     {
         $this->data = $data;
+
+        $this->delimiters = $delimiters;
     }
 
     /**
@@ -189,7 +200,7 @@ class Data implements DataInterface, ArrayAccess
     {
         $value = $this->get($key);
         if (is_array($value) && Util::isAssoc($value)) {
-            return new Data($value);
+            return new Data($value, $this->delimiters);
         }
 
         throw new DataException("Value at '$key' could not be represented as a DataInterface");
@@ -260,7 +271,7 @@ class Data implements DataInterface, ArrayAccess
      *
      * @psalm-return non-empty-list<string>
      *
-     * @psalm-pure
+     * @psalm-mutation-free
      */
     protected function keyToPathArray(string $path): array
     {
@@ -268,6 +279,9 @@ class Data implements DataInterface, ArrayAccess
             throw new InvalidPathException('Path cannot be an empty string');
         }
 
-        return \explode('.', $path);
+        $path = \str_replace($this->delimiters, $this->delimiters[0], $path);
+
+        // @phpstan-ignore-next-line
+        return \explode($this->delimiters[0], $path);
     }
 }

--- a/src/Data.php
+++ b/src/Data.php
@@ -42,12 +42,8 @@ class Data implements DataInterface, ArrayAccess
      */
     public function append(string $key, $value = null): void
     {
-        if (0 == strlen($key)) {
-            throw new InvalidPathException("Key cannot be an empty string");
-        }
-
         $currentValue =& $this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         if (1 == count($keyPath)) {
             if (!isset($currentValue[$key])) {
@@ -88,12 +84,8 @@ class Data implements DataInterface, ArrayAccess
      */
     public function set(string $key, $value = null): void
     {
-        if (0 == strlen($key)) {
-            throw new InvalidPathException("Key cannot be an empty string");
-        }
-
         $currentValue =& $this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         if (1 == count($keyPath)) {
             $currentValue[$key] = $value;
@@ -120,12 +112,8 @@ class Data implements DataInterface, ArrayAccess
      */
     public function remove(string $key): void
     {
-        if (0 == strlen($key)) {
-            throw new InvalidPathException("Key cannot be an empty string");
-        }
-
         $currentValue =& $this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         if (1 == count($keyPath)) {
             unset($currentValue[$key]);
@@ -152,7 +140,7 @@ class Data implements DataInterface, ArrayAccess
     public function get(string $key, $default = null)
     {
         $currentValue = $this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         for ($i = 0; $i < count($keyPath); $i++) {
             $currentKey = $keyPath[$i];
@@ -176,7 +164,7 @@ class Data implements DataInterface, ArrayAccess
     public function has(string $key): bool
     {
         $currentValue = &$this->data;
-        $keyPath = explode('.', $key);
+        $keyPath = $this->keyToPathArray($key);
 
         for ($i = 0; $i < count($keyPath); $i++) {
             $currentKey = $keyPath[$i];
@@ -265,5 +253,21 @@ class Data implements DataInterface, ArrayAccess
     public function offsetUnset($key)
     {
         $this->remove($key);
+    }
+
+    /**
+     * @return string[]
+     *
+     * @psalm-return non-empty-list<string>
+     *
+     * @psalm-pure
+     */
+    protected function keyToPathArray(string $path): array
+    {
+        if (\strlen($path) === 0) {
+            throw new InvalidPathException('Path cannot be an empty string');
+        }
+
+        return \explode('.', $path);
     }
 }

--- a/src/DataInterface.php
+++ b/src/DataInterface.php
@@ -11,6 +11,9 @@
 
 namespace Dflydev\DotAccessData;
 
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
+
 interface DataInterface
 {
     /**
@@ -18,6 +21,8 @@ interface DataInterface
      *
      * @param string $key
      * @param mixed  $value
+     *
+     * @throws InvalidPathException if the given path is empty
      */
     public function append(string $key, $value = null): void;
 
@@ -26,6 +31,9 @@ interface DataInterface
      *
      * @param string $key
      * @param mixed  $value
+     *
+     * @throws InvalidPathException if the given path is empty
+     * @throws DataException if the given path does not target an array
      */
     public function set(string $key, $value = null): void;
 
@@ -33,6 +41,8 @@ interface DataInterface
      * Remove a key
      *
      * @param string $key
+     *
+     * @throws InvalidPathException if the given path is empty
      */
     public function remove(string $key): void;
 
@@ -65,6 +75,8 @@ interface DataInterface
      * @param string $key
      *
      * @return DataInterface
+     *
+     * @throws DataException if the given path does not reference an array
      *
      * @psalm-mutation-free
      */

--- a/src/Exception/DataException.php
+++ b/src/Exception/DataException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is a part of dflydev/dot-access-data.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dflydev\DotAccessData\Exception;
+
+/**
+ * Base runtime exception type thrown by this library
+ */
+class DataException extends \RuntimeException
+{
+}

--- a/src/Exception/InvalidPathException.php
+++ b/src/Exception/InvalidPathException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is a part of dflydev/dot-access-data.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dflydev\DotAccessData\Exception;
+
+/**
+ * Thrown when trying to access an invalid path in the data array
+ */
+class InvalidPathException extends DataException
+{
+}

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -56,6 +56,9 @@ class DataTest extends TestCase
         $this->assertNull($data->get('f.g.h.i'));
         $this->assertEquals($data->get('foo', 'default-value-1'), 'default-value-1', 'Return default value');
         $this->assertEquals($data->get('f.g.h.i', 'default-value-2'), 'default-value-2');
+
+        $this->expectException(InvalidPathException::class);
+        $data->get('', 'broken');
     }
 
     public function testAppend()
@@ -165,6 +168,9 @@ class DataTest extends TestCase
         ) {
             $this->assertFalse($data->has($notExistentKey));
         }
+
+        $this->expectException(InvalidPathException::class);
+        $data->has('', 'broken');
     }
 
     public function testGetData()

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -240,10 +240,6 @@ class DataTest extends TestCase
         $this->assertEquals(['c1', 'c2', 'c3'], $data['c']);
         $this->assertNull($data['foo'], 'Foo should not exist');
         $this->assertNull($data['f.g.h.i']);
-
-        $this->expectException(RuntimeException::class);
-
-        $data = $wrappedData->getData('wrapped.sampleData.a');
     }
 
     public function testOffsetSet()

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -248,7 +248,7 @@ class DataTest extends TestCase
 
     public function testOffsetSet()
     {
-        $data = new Data;
+        $data = new Data();
 
         $this->assertNull($data['a']);
         $this->assertNull($data['b.c']);

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -11,7 +11,8 @@
 
 namespace Dflydev\DotAccessData;
 
-use RuntimeException;
+use Dflydev\DotAccessData\Exception\DataException;
+use Dflydev\DotAccessData\Exception\InvalidPathException;
 use PHPUnit\Framework\TestCase;
 
 class DataTest extends TestCase
@@ -81,7 +82,7 @@ class DataTest extends TestCase
         $this->assertEquals(['I', 'I2'], $data->get('h.i'));
         $this->assertEquals(['L'], $data->get('i.k.l'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->append('', 'broken');
     }
@@ -104,7 +105,7 @@ class DataTest extends TestCase
         $this->assertEquals('F', $data->get('d.e.f'));
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data->get('d'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->set('', 'broken');
     }
@@ -115,7 +116,7 @@ class DataTest extends TestCase
 
         $data->set('a.b.c', 'Should not be able to write to a.b.c.d.e');
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DataException::class);
 
         $data->set('a.b.c.d.e', 'broken');
     }
@@ -137,7 +138,7 @@ class DataTest extends TestCase
         $this->assertNull(null);
         $this->assertEquals('D2', $data->get('b.d.d2'));
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->remove('', 'broken');
     }
@@ -178,7 +179,7 @@ class DataTest extends TestCase
 
         $this->runSampleDataTests($data);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DataException::class);
 
         $data = $wrappedData->getData('wrapped.sampleData.a');
     }
@@ -260,7 +261,7 @@ class DataTest extends TestCase
         $this->assertEquals('F', $data['d.e.f']);
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data['d']);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         $data->set('', 'broken');
     }
@@ -282,7 +283,7 @@ class DataTest extends TestCase
         $this->assertNull(null);
         $this->assertEquals('D2', $data['b.d.d2']);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidPathException::class);
 
         unset($data['']);
     }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -90,6 +90,31 @@ class DataTest extends TestCase
         $data->append('', 'broken');
     }
 
+    public function testAppendWithDifferentDelimiters()
+    {
+        $data = new Data($this->getSampleData(), ['.', '/']);
+
+        $data->append('a', 'B');
+        $data->append('c', 'c4');
+        $data->append('b.c', 'C4');
+        $data->append('b/d.d3', 'D3b');
+        $data->append('b.d/d4', 'D');
+        $data->append('e', 'E');
+        $data->append('f.a', 'b');
+        $data->append('h/i', 'I2');
+        $data->append('i.k.l', 'L');
+
+        $this->assertEquals(['A', 'B'], $data->get('a'));
+        $this->assertEquals(['c1', 'c2', 'c3', 'c4'], $data->get('c'));
+        $this->assertEquals(['C1', 'C2', 'C3', 'C4'], $data->get('b/c'));
+        $this->assertEquals(['D3', 'D3b'], $data->get('b.d.d3'));
+        $this->assertEquals(['D'], $data->get('b/d/d4'));
+        $this->assertEquals(['E'], $data->get('e'));
+        $this->assertEquals(['b'], $data->get('f/a'));
+        $this->assertEquals(['I', 'I2'], $data->get('h.i'));
+        $this->assertEquals(['L'], $data->get('i/k/l'));
+    }
+
     public function testSet()
     {
         $data = new Data();
@@ -111,6 +136,25 @@ class DataTest extends TestCase
         $this->expectException(InvalidPathException::class);
 
         $data->set('', 'broken');
+    }
+
+    public function testSetWithDifferentDelimiters()
+    {
+        $data = new Data([], ['.', '/']);
+
+        $this->assertNull($data->get('a'));
+        $this->assertNull($data->get('b.c'));
+        $this->assertNull($data->get('d/e'));
+
+        $data->set('a', 'A');
+        $data->set('b/c', 'C');
+        $data->set('d.e', ['f' => 'F', 'g' => 'G']);
+
+        $this->assertEquals('A', $data->get('a'));
+        $this->assertEquals(['c' => 'C'], $data->get('b'));
+        $this->assertEquals('C', $data->get('b.c'));
+        $this->assertEquals('F', $data->get('d/e/f'));
+        $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data->get('d'));
     }
 
     public function testSetClobberStringInPath()
@@ -146,11 +190,71 @@ class DataTest extends TestCase
         $data->remove('', 'broken');
     }
 
+    public function testRemoveWithDifferentDelimiters()
+    {
+        $data = new Data($this->getSampleData(), ['.', '/']);
+
+        $data->remove('a');
+        $data->remove('b.c');
+        $data->remove('b/d/d3');
+        $data->remove('d');
+        $data->remove('d.e/f');
+        $data->remove('empty.path');
+
+        $this->assertNull($data->get('a'));
+        $this->assertNull($data->get('b/c'));
+        $this->assertNull($data->get('b.d.d3'));
+        $this->assertNull(null);
+        $this->assertEquals('D2', $data->get('b.d.d2'));
+    }
+
     public function testGet()
     {
         $data = new Data($this->getSampleData());
 
         $this->runSampleDataTests($data);
+    }
+
+    public function testGetWithDifferentDelimiters()
+    {
+        $sample = [
+            'nested' => [
+                'path' => [
+                    'example' => true,
+                ]
+            ],
+        ];
+
+        $data = new Data($sample);
+
+        $this->assertTrue($data->get('nested.path.example'));
+
+        $this->assertNull($data->get('nested/path/example'));
+        $this->assertNull($data->get('nested.path/example'));
+        $this->assertNull($data->get('nested/path.example'));
+
+        $data = new Data($sample, ['.']);
+
+        $this->assertTrue($data->get('nested.path.example'));
+
+        $this->assertNull($data->get('nested/path/example'));
+        $this->assertNull($data->get('nested.path/example'));
+        $this->assertNull($data->get('nested/path.example'));
+
+        $data = new Data($sample, ['/']);
+
+        $this->assertTrue($data->get('nested/path/example'));
+
+        $this->assertNull($data->get('nested.path.example'));
+        $this->assertNull($data->get('nested.path/example'));
+        $this->assertNull($data->get('nested/path.example'));
+
+        $data = new Data($sample, ['.', '/']);
+
+        $this->assertTrue($data->get('nested.path.example'));
+        $this->assertTrue($data->get('nested/path/example'));
+        $this->assertTrue($data->get('nested.path/example'));
+        $this->assertTrue($data->get('nested/path.example'));
     }
 
     public function testHas()
@@ -173,6 +277,23 @@ class DataTest extends TestCase
         $data->has('', 'broken');
     }
 
+    public function testHasWithDifferentDelimiters()
+    {
+        $data = new Data($this->getSampleData(), ['.', '/']);
+
+        foreach (
+            ['a', 'i', 'b.d', 'b/d', 'f.g.h', 'f/g/h', 'h.i', 'h/i', 'b.d.d1', 'b/d/d1'] as $existentKey
+        ) {
+            $this->assertTrue($data->has($existentKey));
+        }
+
+        foreach (
+            ['p', 'b.b1', 'b/b1', 'b.c.C1', 'b/c/C1', 'h.i.I', 'h/i/I', 'b.d.d1.D1', 'b/d/d1/D1'] as $notExistentKey
+        ) {
+            $this->assertFalse($data->has($notExistentKey));
+        }
+    }
+
     public function testGetData()
     {
         $wrappedData = new Data([
@@ -188,6 +309,31 @@ class DataTest extends TestCase
         $this->expectException(DataException::class);
 
         $data = $wrappedData->getData('wrapped.sampleData.a');
+    }
+
+    public function testGetDataUsesSameDelimiters()
+    {
+        $wrappedData = new Data([
+            'wrapped' => [
+                'sampleData' => $this->getSampleData(),
+            ],
+        ], ['/']);
+
+        $data = $wrappedData->getData('wrapped/sampleData');
+
+        $this->assertSame('B', $data->get('b/b'));
+        $this->assertNull($data->get('b.b'));
+
+        $wrappedData = new Data([
+            'wrapped' => [
+                'sampleData' => $this->getSampleData(),
+            ],
+        ], ['.']);
+
+        $data = $wrappedData->getData('wrapped.sampleData');
+
+        $this->assertSame('B', $data->get('b.b'));
+        $this->assertNull($data->get('b/b'));
     }
 
     public function testImport()
@@ -249,6 +395,19 @@ class DataTest extends TestCase
         $this->assertNull($data['f.g.h.i']);
     }
 
+    public function testOffsetGetWithDifferentDelimiters()
+    {
+        $data = new Data($this->getSampleData(), ['.', '/']);
+
+        $this->assertEquals('A', $data['a']);
+        $this->assertEquals('B', $data['b/b']);
+        $this->assertEquals(['C1', 'C2', 'C3'], $data['b.c']);
+        $this->assertEquals('D3', $data['b/d/d3']);
+        $this->assertEquals(['c1', 'c2', 'c3'], $data['c']);
+        $this->assertNull($data['foo'], 'Foo should not exist');
+        $this->assertNull($data['f.g/h.i']);
+    }
+
     public function testOffsetSet()
     {
         $data = new Data();
@@ -272,6 +431,33 @@ class DataTest extends TestCase
         $data->set('', 'broken');
     }
 
+    public function testOffsetSetWithDifferentDelimiters()
+    {
+        $data = new Data([], ['.', '/']);
+
+        $this->assertNull($data['a']);
+        $this->assertNull($data['b.c']);
+        $this->assertNull($data['b/c']);
+        $this->assertNull($data['d.e']);
+        $this->assertNull($data['d/e']);
+
+        $data['a'] = 'A';
+        $data['b.c'] = 'C';
+        $data['d/e'] = ['f' => 'F', 'g' => 'G'];
+
+        $this->assertEquals('A', $data['a']);
+        $this->assertEquals(['c' => 'C'], $data['b']);
+        $this->assertEquals('C', $data['b.c']);
+        $this->assertEquals('C', $data['b/c']);
+        $this->assertEquals('F', $data['d.e.f']);
+        $this->assertEquals('F', $data['d/e/f']);
+        $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data['d']);
+
+        $this->expectException(InvalidPathException::class);
+
+        $data->set('', 'broken');
+    }
+
     public function testOffsetUnset()
     {
         $data = new Data($this->getSampleData());
@@ -288,6 +474,28 @@ class DataTest extends TestCase
         $this->assertNull($data['b.d.d3']);
         $this->assertNull(null);
         $this->assertEquals('D2', $data['b.d.d2']);
+
+        $this->expectException(InvalidPathException::class);
+
+        unset($data['']);
+    }
+
+    public function testOffsetUnsetWithDifferentDelimiters()
+    {
+        $data = new Data($this->getSampleData(), ['.', '/']);
+
+        unset($data['a']);
+        unset($data['b.c']);
+        unset($data['b/d/d3']);
+        unset($data['d']);
+        unset($data['d/e.f']);
+        unset($data['empty.path']);
+
+        $this->assertNull($data['a']);
+        $this->assertNull($data['b/c']);
+        $this->assertNull($data['b.d.d3']);
+        $this->assertNull(null);
+        $this->assertEquals('D2', $data['b.d/d2']);
 
         $this->expectException(InvalidPathException::class);
 


### PR DESCRIPTION
This PR is one possible implementation for #21 (the alternative being #24) where the delimiters can be configured via a new constructor parameter.

Note that #23 should be merged before this one.