### PR TITLE
Minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ isset($data['name']) === $data->has('name');
 unset($data['name']);
 ```
 
+`/` can also be used as a path delimiter:
+
+```php
+$data->set('a/b/c', 'd');
+echo $data->get('a/b/c'); // "d"
+
+$data->get('a/b/c') === $data->get('a.b.c'); // true
+```
+
 License
 -------
 

--- a/src/Data.php
+++ b/src/Data.php
@@ -49,23 +49,8 @@ class Data implements DataInterface, ArrayAccess
         $currentValue =& $this->data;
         $keyPath = $this->keyToPathArray($key);
 
-        if (1 == count($keyPath)) {
-            if (!isset($currentValue[$key])) {
-                $currentValue[$key] = [];
-            }
-            if (!is_array($currentValue[$key])) {
-                // Promote this key to an array.
-                // TODO: Is this really what we want to do?
-                $currentValue[$key] = [$currentValue[$key]];
-            }
-            $currentValue[$key][] = $value;
-
-            return;
-        }
-
         $endKey = array_pop($keyPath);
-        for ($i = 0; $i < count($keyPath); $i++) {
-            $currentKey =& $keyPath[$i];
+        foreach ($keyPath as $currentKey) {
             if (! isset($currentValue[$currentKey])) {
                 $currentValue[$currentKey] = [];
             }
@@ -75,11 +60,13 @@ class Data implements DataInterface, ArrayAccess
         if (!isset($currentValue[$endKey])) {
             $currentValue[$endKey] = [];
         }
+
         if (!is_array($currentValue[$endKey])) {
+            // Promote this key to an array.
+            // TODO: Is this really what we want to do?
             $currentValue[$endKey] = [$currentValue[$endKey]];
         }
-        // Promote this key to an array.
-        // TODO: Is this really what we want to do?
+
         $currentValue[$endKey][] = $value;
     }
 
@@ -91,15 +78,8 @@ class Data implements DataInterface, ArrayAccess
         $currentValue =& $this->data;
         $keyPath = $this->keyToPathArray($key);
 
-        if (1 == count($keyPath)) {
-            $currentValue[$key] = $value;
-
-            return;
-        }
-
         $endKey = array_pop($keyPath);
-        for ($i = 0; $i < count($keyPath); $i++) {
-            $currentKey =& $keyPath[$i];
+        foreach ($keyPath as $currentKey) {
             if (!isset($currentValue[$currentKey])) {
                 $currentValue[$currentKey] = [];
             }
@@ -119,15 +99,8 @@ class Data implements DataInterface, ArrayAccess
         $currentValue =& $this->data;
         $keyPath = $this->keyToPathArray($key);
 
-        if (1 == count($keyPath)) {
-            unset($currentValue[$key]);
-
-            return;
-        }
-
         $endKey = array_pop($keyPath);
-        for ($i = 0; $i < count($keyPath); $i++) {
-            $currentKey =& $keyPath[$i];
+        foreach ($keyPath as $currentKey) {
             if (!isset($currentValue[$currentKey])) {
                 return;
             }
@@ -146,8 +119,7 @@ class Data implements DataInterface, ArrayAccess
         $currentValue = $this->data;
         $keyPath = $this->keyToPathArray($key);
 
-        for ($i = 0; $i < count($keyPath); $i++) {
-            $currentKey = $keyPath[$i];
+        foreach ($keyPath as $currentKey) {
             if (!isset($currentValue[$currentKey])) {
                 return $default;
             }
@@ -168,10 +140,8 @@ class Data implements DataInterface, ArrayAccess
     public function has(string $key): bool
     {
         $currentValue = &$this->data;
-        $keyPath = $this->keyToPathArray($key);
 
-        for ($i = 0; $i < count($keyPath); $i++) {
-            $currentKey = $keyPath[$i];
+        foreach ($this->keyToPathArray($key) as $currentKey) {
             if (
                 !is_array($currentValue) ||
                 !array_key_exists($currentKey, $currentValue)

--- a/src/Data.php
+++ b/src/Data.php
@@ -47,7 +47,7 @@ class Data implements DataInterface, ArrayAccess
     public function append(string $key, $value = null): void
     {
         $currentValue =& $this->data;
-        $keyPath = $this->keyToPathArray($key);
+        $keyPath = self::keyToPathArray($key);
 
         $endKey = array_pop($keyPath);
         foreach ($keyPath as $currentKey) {
@@ -76,7 +76,7 @@ class Data implements DataInterface, ArrayAccess
     public function set(string $key, $value = null): void
     {
         $currentValue =& $this->data;
-        $keyPath = $this->keyToPathArray($key);
+        $keyPath = self::keyToPathArray($key);
 
         $endKey = array_pop($keyPath);
         foreach ($keyPath as $currentKey) {
@@ -97,7 +97,7 @@ class Data implements DataInterface, ArrayAccess
     public function remove(string $key): void
     {
         $currentValue =& $this->data;
-        $keyPath = $this->keyToPathArray($key);
+        $keyPath = self::keyToPathArray($key);
 
         $endKey = array_pop($keyPath);
         foreach ($keyPath as $currentKey) {
@@ -117,7 +117,7 @@ class Data implements DataInterface, ArrayAccess
     public function get(string $key, $default = null)
     {
         $currentValue = $this->data;
-        $keyPath = $this->keyToPathArray($key);
+        $keyPath = self::keyToPathArray($key);
 
         foreach ($keyPath as $currentKey) {
             if (!isset($currentValue[$currentKey])) {
@@ -141,7 +141,7 @@ class Data implements DataInterface, ArrayAccess
     {
         $currentValue = &$this->data;
 
-        foreach ($this->keyToPathArray($key) as $currentKey) {
+        foreach (self::keyToPathArray($key) as $currentKey) {
             if (
                 !is_array($currentValue) ||
                 !array_key_exists($currentKey, $currentValue)
@@ -230,13 +230,15 @@ class Data implements DataInterface, ArrayAccess
     }
 
     /**
+     * @param string $path
+     *
      * @return string[]
      *
      * @psalm-return non-empty-list<string>
      *
      * @psalm-pure
      */
-    protected function keyToPathArray(string $path): array
+    protected static function keyToPathArray(string $path): array
     {
         if (\strlen($path) === 0) {
             throw new InvalidPathException('Path cannot be an empty string');

--- a/src/Data.php
+++ b/src/Data.php
@@ -84,7 +84,7 @@ class Data implements DataInterface, ArrayAccess
                 $currentValue[$currentKey] = [];
             }
             if (!is_array($currentValue[$currentKey])) {
-                throw new DataException("Key path at $currentKey of $key cannot be indexed into (is not an array)");
+                throw new DataException(sprintf('Key path "%s" within "%s" cannot be indexed into (is not an array)', $currentKey, self::formatPath($key)));
             }
             $currentValue =& $currentValue[$currentKey];
         }
@@ -166,7 +166,7 @@ class Data implements DataInterface, ArrayAccess
             return new Data($value);
         }
 
-        throw new DataException("Value at '$key' could not be represented as a DataInterface");
+        throw new DataException(sprintf('Value at "%s" could not be represented as a DataInterface', self::formatPath($key)));
     }
 
     /**
@@ -247,5 +247,21 @@ class Data implements DataInterface, ArrayAccess
         $path = \str_replace(self::DELIMITERS, '.', $path);
 
         return \explode('.', $path);
+    }
+
+    /**
+     * @param string|string[] $path
+     *
+     * @return string
+     *
+     * @psalm-pure
+     */
+    protected static function formatPath($path): string
+    {
+        if (is_string($path)) {
+            $path = self::keyToPathArray($path);
+        }
+
+        return implode(' » ', $path);
     }
 }

--- a/src/Data.php
+++ b/src/Data.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is a part of dflydev/dot-access-data.
  *

--- a/src/DataInterface.php
+++ b/src/DataInterface.php
@@ -21,40 +21,51 @@ interface DataInterface
     /**
      * Append a value to a key (assumes key refers to an array value)
      *
+     * If the key does not yet exist it will be created.
+     * If the key references a non-array it's existing contents will be added into a new array before appending the new value.
+     *
      * @param string $key
      * @param mixed  $value
      *
-     * @throws InvalidPathException if the given path is empty
+     * @throws InvalidPathException if the given key is empty
      */
     public function append(string $key, $value = null): void;
 
     /**
      * Set a value for a key
      *
+     * If the key does not yet exist it will be created.
+     *
      * @param string $key
      * @param mixed  $value
      *
-     * @throws InvalidPathException if the given path is empty
-     * @throws DataException if the given path does not target an array
+     * @throws InvalidPathException if the given key is empty
+     * @throws DataException if the given key does not target an array
      */
     public function set(string $key, $value = null): void;
 
     /**
      * Remove a key
      *
+     * No exception will be thrown if the key does not exist
+     *
      * @param string $key
      *
-     * @throws InvalidPathException if the given path is empty
+     * @throws InvalidPathException if the given key is empty
      */
     public function remove(string $key): void;
 
     /**
      * Get the raw value for a key
      *
+     * If the key does not exist, the provided default value (or null) will be returned instead.
+     *
      * @param string $key
      * @param mixed $default
      *
      * @return mixed
+     *
+     * @throws InvalidPathException if the given key is empty
      *
      * @psalm-mutation-free
      */
@@ -67,6 +78,8 @@ interface DataInterface
      *
      * @return bool
      *
+     * @throws InvalidPathException if the given key is empty
+     *
      * @psalm-mutation-free
      */
     public function has(string $key): bool;
@@ -78,7 +91,8 @@ interface DataInterface
      *
      * @return DataInterface
      *
-     * @throws DataException if the given path does not reference an array
+     * @throws InvalidPathException if the given key is empty
+     * @throws DataException if the given key does not reference an array
      *
      * @psalm-mutation-free
      */

--- a/src/DataInterface.php
+++ b/src/DataInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is a part of dflydev/dot-access-data.
  *

--- a/src/Exception/DataException.php
+++ b/src/Exception/DataException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is a part of dflydev/dot-access-data.
  *

--- a/src/Exception/InvalidPathException.php
+++ b/src/Exception/InvalidPathException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is a part of dflydev/dot-access-data.
  *

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is a part of dflydev/dot-access-data.
  *

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -191,10 +191,18 @@ class DataTest extends TestCase
         $data = $wrappedData->getData('wrapped.sampleData');
 
         $this->runSampleDataTests($data);
+    }
+
+    public function testGetDataOnNonArrayValue()
+    {
+        $data = new Data([
+            'foo' => 'bar',
+        ]);
 
         $this->expectException(DataException::class);
+        $this->expectExceptionMessageRegExp('/could not be represented as a DataInterface/');
 
-        $data = $wrappedData->getData('wrapped.sampleData.a');
+        $data->getData('foo');
     }
 
     public function testImport()

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -65,6 +65,7 @@ class DataTest extends TestCase
         $this->assertEquals($data->get('f/g/h/i', 'default-value-2'), 'default-value-2');
 
         $this->expectException(InvalidPathException::class);
+        $this->expectExceptionMessage('Path cannot be an empty string');
         $data->get('', 'broken');
     }
 
@@ -93,7 +94,7 @@ class DataTest extends TestCase
         $this->assertEquals(['L'], $data->get('i.k.l'));
 
         $this->expectException(InvalidPathException::class);
-
+        $this->expectExceptionMessage('Path cannot be an empty string');
         $data->append('', 'broken');
     }
 
@@ -116,7 +117,7 @@ class DataTest extends TestCase
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data->get('d'));
 
         $this->expectException(InvalidPathException::class);
-
+        $this->expectExceptionMessage('Path cannot be an empty string');
         $data->set('', 'broken');
     }
 
@@ -127,7 +128,7 @@ class DataTest extends TestCase
         $data->set('a.b.c', 'Should not be able to write to a.b.c.d.e');
 
         $this->expectException(DataException::class);
-
+        $this->expectExceptionMessage('Key path "c" within "a » b » c » d » e" cannot be indexed into (is not an array)');
         $data->set('a.b.c.d.e', 'broken');
     }
 
@@ -149,7 +150,7 @@ class DataTest extends TestCase
         $this->assertEquals('D2', $data->get('b.d.d2'));
 
         $this->expectException(InvalidPathException::class);
-
+        $this->expectExceptionMessage('Path cannot be an empty string');
         $data->remove('', 'broken');
     }
 
@@ -177,6 +178,7 @@ class DataTest extends TestCase
         }
 
         $this->expectException(InvalidPathException::class);
+        $this->expectExceptionMessage('Path cannot be an empty string');
         $data->has('', 'broken');
     }
 
@@ -200,8 +202,7 @@ class DataTest extends TestCase
         ]);
 
         $this->expectException(DataException::class);
-        $this->expectExceptionMessageRegExp('/could not be represented as a DataInterface/');
-
+        $this->expectExceptionMessage('Value at "foo" could not be represented as a DataInterface');
         $data->getData('foo');
     }
 
@@ -287,7 +288,7 @@ class DataTest extends TestCase
         $this->assertEquals(['e' => ['f' => 'F', 'g' => 'G']], $data['d']);
 
         $this->expectException(InvalidPathException::class);
-
+        $this->expectExceptionMessage('Path cannot be an empty string');
         $data->set('', 'broken');
     }
 
@@ -309,7 +310,7 @@ class DataTest extends TestCase
         $this->assertEquals('D2', $data['b.d.d2']);
 
         $this->expectException(InvalidPathException::class);
-
+        $this->expectExceptionMessage('Path cannot be an empty string');
         unset($data['']);
     }
 }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is a part of dflydev/dot-access-data.
  *

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is a part of dflydev/dot-access-data.
  *


### PR DESCRIPTION
 - Use strict types
 - Removes one-off checks for single-key paths (since the main loop won't execute if there's only one key, making the old code redundant)
 - Uses `foreach` loops instead of `for` loops with frequent `count()` checks
 - Enhances the interface documentation
 - Fixes a test that wasn't running
 - Documents the new `/`-based delimiter path feature
 - Improves some exception messages and adds tests for them