### PR TITLE
Add new MERGE import mode

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -200,17 +200,17 @@ class Data implements DataInterface, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function import(array $data, bool $clobber = true): void
+    public function import(array $data, int $mode = self::REPLACE): void
     {
-        $this->data = Util::mergeAssocArray($this->data, $data, $clobber);
+        $this->data = Util::mergeAssocArray($this->data, $data, $mode);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function importData(DataInterface $data, bool $clobber = true): void
+    public function importData(DataInterface $data, int $mode = self::REPLACE): void
     {
-        $this->import($data->export(), $clobber);
+        $this->import($data->export(), $mode);
     }
 
     /**

--- a/src/DataInterface.php
+++ b/src/DataInterface.php
@@ -16,6 +16,10 @@ use Dflydev\DotAccessData\Exception\InvalidPathException;
 
 interface DataInterface
 {
+    public const PRESERVE = 0;
+    public const REPLACE = 1;
+    public const MERGE = 2;
+
     /**
      * Append a value to a key (assumes key refers to an array value)
      *
@@ -85,18 +89,18 @@ interface DataInterface
     /**
      * Import data into existing data
      *
-     * @param array<string, mixed> $data
-     * @param bool                 $clobber
+     * @param array<string, mixed>                     $data
+     * @param self::PRESERVE|self::REPLACE|self::MERGE $mode
      */
-    public function import(array $data, bool $clobber = true): void;
+    public function import(array $data, int $mode = self::REPLACE): void;
 
     /**
      * Import data from an external data into existing data
      *
-     * @param DataInterface $data
-     * @param bool          $clobber
+     * @param DataInterface                            $data
+     * @param self::PRESERVE|self::REPLACE|self::MERGE $mode
      */
-    public function importData(DataInterface $data, bool $clobber = true): void;
+    public function importData(DataInterface $data, int $mode = self::REPLACE): void;
 
     /**
      * Export data as raw data

--- a/src/Util.php
+++ b/src/Util.php
@@ -47,7 +47,7 @@ class Util
             return array_merge($to, $from);
         }
 
-        if (is_array($from)) {
+        if (is_array($from) && is_array($to)) {
             foreach ($from as $k => $v) {
                 if (!isset($to[$k])) {
                     $to[$k] = $v;

--- a/src/Util.php
+++ b/src/Util.php
@@ -35,26 +35,42 @@ class Util
      *
      * @param mixed $to
      * @param mixed $from
-     * @param bool  $clobber
+     * @param DataInterface::PRESERVE|DataInterface::REPLACE|DataInterface::MERGE $mode
      *
      * @return mixed
      *
      * @psalm-pure
      */
-    public static function mergeAssocArray($to, $from, $clobber = true)
+    public static function mergeAssocArray($to, $from, int $mode = DataInterface::REPLACE)
     {
+        if ($mode === DataInterface::MERGE && self::isList($to) && self::isList($from)) {
+            return array_merge($to, $from);
+        }
+
         if (is_array($from)) {
             foreach ($from as $k => $v) {
                 if (!isset($to[$k])) {
                     $to[$k] = $v;
                 } else {
-                    $to[$k] = self::mergeAssocArray($to[$k], $v, $clobber);
+                    $to[$k] = self::mergeAssocArray($to[$k], $v, $mode);
                 }
             }
 
             return $to;
         }
 
-        return $clobber ? $from : $to;
+        return $mode === DataInterface::PRESERVE ? $to : $from;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     *
+     * @psalm-pure
+     */
+    private static function isList($value): bool
+    {
+        return is_array($value) && array_values($value) === $value;
     }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -25,9 +25,14 @@ class UtilTest extends TestCase
     /**
      * @dataProvider mergeAssocArrayProvider
      */
-    public function testMergeAssocArray($message, $to, $from, $clobber, $expectedResult)
+    public function testMergeAssocArray($message, $to, $from, $mode, $expectedResult)
     {
-        $result = Util::mergeAssocArray($to, $from, $clobber);
+        if ($mode === null) {
+            $result = Util::mergeAssocArray($to, $from);
+        } else {
+            $result = Util::mergeAssocArray($to, $from, $mode);
+        }
+
         $this->assertEquals($expectedResult, $result, $message);
     }
 
@@ -35,49 +40,49 @@ class UtilTest extends TestCase
     {
         return [
             [
-                'Clobber should replace to value with from value for strings (shallow)',
+                'Overwrite should replace to value with from value for strings (shallow)',
                 // to
                 ['a' => 'A'],
                 // from
                 ['a' => 'B'],
-                // clobber
-                true,
+                // mode
+                DataInterface::REPLACE,
                 // expected result
                 ['a' => 'B'],
             ],
 
             [
-                'Clobber should replace to value with from value for strings (deep)',
+                'Overwrite should replace to value with from value for strings (deep)',
                 // to
                 ['a' => ['b' => 'B']],
                 // from
                 ['a' => ['b' => 'C']],
-                // clobber
-                true,
+                // mode
+                DataInterface::REPLACE,
                 // expected result
                 ['a' => ['b' => 'C']]
             ],
 
             [
-                'Clobber should  NOTreplace to value with from value for strings (shallow)',
+                'Existing values are not replaced in preserve mode (shallow)',
                 // to
                 ['a' => 'A'],
                 // from
                 ['a' => 'B'],
-                // clobber
-                false,
+                // mode
+                DataInterface::PRESERVE,
                 // expected result
                 ['a' => 'A'],
             ],
 
             [
-                'Clobber should NOT replace to value with from value for strings (deep)',
+                'Existing values are not replaced in preserve mode (deep)',
                 // to
                 ['a' => ['b' => 'B']],
                 // from
                 ['a' => ['b' => 'C']],
-                // clobber
-                false,
+                // mode
+                DataInterface::PRESERVE,
                 // expected result
                 ['a' => ['b' => 'B']],
             ],
@@ -88,34 +93,46 @@ class UtilTest extends TestCase
                 ['a' => ['b' => 'B']],
                 // from
                 ['a' => ['c' => 'C']],
-                // clobber
+                // mode
                 null,
                 // expected result
                 ['a' => ['b' => 'B', 'c' => 'C']],
             ],
 
             [
-                'Arrays should be replaced (with clobber enabled)',
+                'Arrays should be replaced',
                 // to
                 ['a' => ['b', 'c']],
                 // from
                 ['a' => ['B', 'C']],
-                // clobber
-                true,
+                // mode
+                DataInterface::REPLACE,
                 // expected result
                 ['a' => ['B', 'C']],
             ],
 
             [
-                'Arrays should be NOT replaced (with clobber disabled)',
+                'Arrays should be preserved',
                 // to
                 ['a' => ['b', 'c']],
                 // from
                 ['a' => ['B', 'C']],
-                // clobber
-                false,
+                // mode
+                DataInterface::PRESERVE,
                 // expected result
                 ['a' => ['b', 'c']],
+            ],
+
+            [
+                'Arrays should be merged/appended (when using MERGE)',
+                // to
+                ['a' => 1, 'b' => 1, 'n' => [1]],
+                // from
+                ['a' => 2, 'c' => 2, 'n' => [2]],
+                // mode
+                DataInterface::MERGE,
+                // expected result
+                ['a' => 2, 'b' => 1, 'c' => 2, 'n' => [1, 2]]
             ],
         ];
     }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -126,13 +126,13 @@ class UtilTest extends TestCase
             [
                 'Arrays should be merged/appended (when using MERGE)',
                 // to
-                ['a' => 1, 'b' => 1, 'n' => [1]],
+                ['a' => 1, 'b' => 1, 'n' => [1], 'x' => 'string', 'y' => ['stringindex' => 1]],
                 // from
-                ['a' => 2, 'c' => 2, 'n' => [2]],
+                ['a' => 2, 'c' => 2, 'n' => [2], 'x' => ['array'], 'y' => [2]],
                 // mode
                 DataInterface::MERGE,
                 // expected result
-                ['a' => 2, 'b' => 1, 'c' => 2, 'n' => [1, 2]]
+                ['a' => 2, 'b' => 1, 'c' => 2, 'n' => [1, 2], 'x' => ['array'], 'y' => ['stringindex' => 1, 0 => 2]]
             ],
         ];
     }


### PR DESCRIPTION
Implements/resolves #31 

Also includes a fix for this bug:

```php
$value1 = ['test' => 'string'];
$value2 = ['test' => ['array']];
$value = Util::mergeAssocArray($value1, $value2);

// Before fix: ['test' => 'atring']
// After fix:  ['test' => ['array']]
```