### PR TITLE
Prepare to release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2020-12-31
+
 ### Added
  - Added support for both `.` and `/`-delimited key paths (#24)
  - Added parameter and return types to everything; enabled strict type checks (#18)
@@ -43,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Initial release!**
 
-[Unreleased]: https://github.com/dflydev/dflydev-dot-access-data/compare/v2.0.0...main
+[Unreleased]: https://github.com/dflydev/dflydev-dot-access-data/compare/v3.0.0...main
+[3.0.0]: https://github.com/dflydev/dflydev-dot-access-data/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/dflydev/dflydev-dot-access-data/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/dflydev/dflydev-dot-access-data/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/dflydev/dflydev-dot-access-data/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
I have no other changes to suggest for the v3.0.0 release.  Everything currently in the `main` branch fits my needs perfectly :)  

If/when you are ready to tag a new release, this MR will update the changelog accordingly.  Recommended next steps to create the v3 release:

1. Make sure the release date (shown on line 10) of this modified `CHANGELOG.md` is correct
2. Apply the changes
3. Create a new `v3.0.0` tag from `main` (which would include the updated changelog)
4. Copypaste lines 12-26 of the changelog into the GitHub release notes for that new tag
5. ???
6. Profit!