### PR TITLE
Implement ReturnTypeWillChange attributes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,9 @@ jobs:
                     - php: '8.0'
                       coverage: false
                       composer-flags: '--ignore-platform-req=php'
+                    - php: '8.1'
+                      coverage: false
+                      composer-flags: '--ignore-platform-req=php'
 
         steps:
             - uses: actions/checkout@v2
@@ -51,9 +54,9 @@ jobs:
 
             - run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            - name: "Use PHPUnit 9.3+ on PHP 8"
+            - name: "Use PHPUnit 9.3+ on PHP 8.0 & PHP 8.1"
               run: composer require --no-update --dev phpunit/phpunit:^9.3
-              if: "matrix.php == '8.0'"
+              if: "matrix.php == '8.0' || matrix.php == '8.1'"
 
             - run: composer update --no-progress ${{ matrix.composer-flags }}
 

--- a/src/Data.php
+++ b/src/Data.php
@@ -204,6 +204,7 @@ class Data implements DataInterface, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return $this->has($key);
@@ -212,6 +213,7 @@ class Data implements DataInterface, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key, null);
@@ -222,6 +224,7 @@ class Data implements DataInterface, ArrayAccess
      *
      * @param string $key
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->set($key, $value);
@@ -230,6 +233,7 @@ class Data implements DataInterface, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         $this->remove($key);


### PR DESCRIPTION
Adds ReturnTypeWillChange to suppress PHP 8.1 warnings. At the moment this is blocking the laravel/framework build from running the full test suite on PHP 8.1.﻿
