### PR TITLE
Upgrade to Psalm 4 to fix issues since 3.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
         "scrutinizer/ocular": "1.6.0",
         "squizlabs/php_codesniffer": "^3.5",
-        "vimeo/psalm": "^3.14"
+        "vimeo/psalm": "^4.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Data.php
+++ b/src/Data.php
@@ -145,7 +145,7 @@ class Data implements DataInterface, ArrayAccess
      */
     public function has(string $key): bool
     {
-        $currentValue = &$this->data;
+        $currentValue = $this->data;
 
         foreach (self::keyToPathArray($key) as $currentKey) {
             if (
@@ -154,7 +154,7 @@ class Data implements DataInterface, ArrayAccess
             ) {
                 return false;
             }
-            $currentValue = &$currentValue[$currentKey];
+            $currentValue = $currentValue[$currentKey];
         }
 
         return true;
@@ -223,6 +223,7 @@ class Data implements DataInterface, ArrayAccess
      * {@inheritdoc}
      *
      * @param string $key
+     * @param mixed $value
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)


### PR DESCRIPTION
The mbstring polyfill added ??= which causes errors with Psalm 3. See: https://github.com/symfony/polyfill-mbstring/commit/11d0d87a1d1ef6a3d8158fcb756387786490cd08#r45855304

This also removes the use of references in Data->has, because Psalm (rightly) considers that impure. This shouldn't affect performance in any noticeable way, since arrays are copy-on-write. It is essentially identical to `Data->get` now 🤷‍♂️