### PR TITLE
Added native return types

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -205,13 +205,15 @@ class Data implements DataInterface, ArrayAccess
      * {@inheritdoc}
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return $this->has($key);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($key)
@@ -226,7 +228,7 @@ class Data implements DataInterface, ArrayAccess
      * @param mixed $value
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->set($key, $value);
     }
@@ -235,7 +237,7 @@ class Data implements DataInterface, ArrayAccess
      * {@inheritdoc}
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         $this->remove($key);
     }


### PR DESCRIPTION
The `ArrayAccess` methods have native return types since PHP 7, which can result in deprecation messages like this (when using Symfony's debug classloader):

```
2022-05-24T14:21:41+00:00 [info] User Deprecated: Method "ArrayAccess::offsetUnset()" might add "void" as a native return type declaration in the future. Do the same in implementation "Dflydev\DotAccessData\Data" now to avoid errors or add an explicit @return annotation to suppress this message.
```

This PR adds native return types where possible.