### PR TITLE
add return types to doc blocks

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
     errorLevel="3"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/Data.php
+++ b/src/Data.php
@@ -203,6 +203,8 @@ class Data implements DataInterface, ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function offsetExists($key)
@@ -212,6 +214,8 @@ class Data implements DataInterface, ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($key)
@@ -224,6 +228,8 @@ class Data implements DataInterface, ArrayAccess
      *
      * @param string $key
      * @param mixed $value
+     *
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
@@ -233,6 +239,8 @@ class Data implements DataInterface, ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($key)


### PR DESCRIPTION
```
  1x: Method "ArrayAccess::offsetExists()" might add "bool" as a native return type declaration in the future. Do the same in implementation "Dflydev\DotAccessData\Data" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Dflydev\DotAccessData\Data" now to avoid errors or add an explicit @return annotation to suppress this message.


  1x: Method "ArrayAccess::offsetSet()" might add "void" as a native return type declaration in the future. Do the same in implementation "Dflydev\DotAccessData\Data" now to avoid errors or add an explicit @return annotation to suppress this message.


  1x: Method "ArrayAccess::offsetUnset()" might add "void" as a native return type declaration in the future. Do the same in implementation "Dflydev\DotAccessData\Data" now to avoid errors or add an explicit @return annotation to suppress this message.
```

See #44 

