### PR TITLE
[Fix] PHP 8.4 compatibility

### DIFF
--- a/src/Exception/MissingPathException.php
+++ b/src/Exception/MissingPathException.php
@@ -23,7 +23,7 @@ class MissingPathException extends DataException
     /** @var string */
     protected $path;
 
-    public function __construct(string $path, string $message = '', int $code = 0, Throwable $previous = null)
+    public function __construct(string $path, string $message = '', int $code = 0, ?Throwable $previous = null)
     {
         $this->path = $path;
 


### PR DESCRIPTION
>  Dflydev\DotAccessData\Exception\MissingPathException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead